### PR TITLE
[Feature] Get guest token from Twitter and save in headers

### DIFF
--- a/domain/src/main/scala/zio/twitter/application/scraper/Scraper.scala
+++ b/domain/src/main/scala/zio/twitter/application/scraper/Scraper.scala
@@ -1,26 +1,29 @@
 package zio.twitter.application.scraper
 
-import zio.Duration
-import zio.Schedule
-import zio.ZLayer
-import zio.durationInt
+import zio.*
 import zio.http.Header.UserAgent
 import zio.http.*
 import zio.http.netty.NettyConfig
 
 trait Scraper:
 
-  val name: String
-  private val connRetries: Int = 3
+  protected val name: String
+  protected val connRetries: Int = 3
 
   def getItems: List[String]
+
+  protected def get(url: URL, headers: Headers): Task[Response] =
+    request(Method.GET, url, Body.empty, headers)
+
+  protected def post(url: URL, body: Body, headers: Headers): Task[Response] =
+    request(Method.POST, url, body, headers)
 
   private def request(
     method: Method,
     url: URL,
     body: Body,
     headers: Headers,
-    proxy: Proxy,
+    proxy: Proxy = Proxy.empty,
     timeout: Duration = 10.seconds
   ) =
     val headersWithUserAgent =

--- a/domain/src/main/scala/zio/twitter/application/scraper/TwitterSearchScraper.scala
+++ b/domain/src/main/scala/zio/twitter/application/scraper/TwitterSearchScraper.scala
@@ -1,0 +1,120 @@
+package zio.twitter.application.scraper
+
+import zio.RIO
+import zio.URIO
+import zio.ZIO
+import zio.ZState
+import zio.duration2DurationOps
+import zio.durationInt
+import zio.http.Header.Custom
+import zio.http.Header.SetCookie
+import zio.http.Header.{Cookie => HCookie}
+import zio.http.*
+import zio.json.DecoderOps
+import zio.json.ast.Json
+import zio.json.ast.JsonCursor
+import zio.twitter.application.scraper.TwitterUtils.*
+import zio.twitter.domain.scraper.ValueClasses.NonEmptyString
+
+import java.net.URI
+
+import TwitterSearchScraper.*
+
+final class TwitterSearchScraper(
+  query: NonEmptyString,
+  mode: TwitterSearchScraperMode = TwitterSearchScraperMode.Live,
+  maxEmptyPages: Int = 20,
+  override protected val connRetries: Int = 3
+) extends Scraper:
+
+  override protected val name: String = "twitter-search"
+
+  private val url     = URL
+    .fromURI(
+      URI(
+        "https",
+        "twitter.com",
+        "/search",
+        s"f=live&lang=en&q=$query&src=spelling_expansion_revert_click",
+        null
+      )
+    )
+    .get
+  private val headers = getHeaders(url)
+
+  // Later: Change a dummy implementation
+  override def getItems: List[String] = Nil
+//    val paginationVars =
+
+  private def iterApiData() = ???
+
+  private def getApiData = ???
+
+  // Later: Change from public to private
+  def getHeadersWithGuestToken: RIO[ZState[State], Headers] =
+    val getGuestTokenManager =
+      for
+        resp <- get(url, headers)
+        text <- resp.body.asString
+        gt   <- retrieveGuestTokenManager(text, resp.headers.get(HCookie))
+      yield gt
+    for
+      gtManager    <- ZIO.getStateWith[State](_.guestTokenManager)
+      newGtManager <- getGuestTokenManager.when(gtManager.token.isEmpty)
+    yield headers ++ newGtManager.fold(Headers.empty)(gtManager =>
+      Headers(gtCookie(gtManager), gtHeader(gtManager.token.get))
+    )
+
+  private def retrieveGuestTokenManager(text: String, cookie: Option[HCookie]) =
+
+    val fromText        = GuestTokenRegex.findFirstMatchIn(text).map(_.group(1))
+    lazy val fromCookie =
+      for
+        c  <- cookie
+        gt <- c.value.toCons.find(_.name == "gt")
+      yield gt.content
+    lazy val fromApi    =
+      val url = URL
+        .fromURI(
+          URI("https", "api.twitter.com", "/1.1/guest/activate.json", null)
+        )
+        .get
+
+      for
+        resp <- post(url, Body.empty, headers)
+        text <- resp.body.asString
+        json <- ZIO.fromEither(text.fromJson[Json])
+        gt   <- ZIO.fromEither(json.get(JsonCursor.field("guest_token").isString))
+      yield gt.value
+
+    for
+      gt       <-
+        (ZIO.getOrFail(fromText) <> ZIO.getOrFail(fromCookie) <> fromApi)
+          .orDieWith(_ =>
+            throw new NoSuchElementException("Unable to retrieve guest token")
+          )
+      gtManager = GuestTokenManager(token = Some(gt))
+      _        <- ZIO.setState[State](State(gtManager))
+    yield gtManager
+
+object TwitterSearchScraper:
+  private val GuestTokenRegex    =
+    """document.cookie = decodeURIComponent\("gt=(\d+); Max-Age=10800; Domain=.twitter.com; Path=/; Secure"\)""".r
+  private val GuestTokenValidity = 10800.seconds
+
+  // Later: Change from public to private
+  final case class State(guestTokenManager: GuestTokenManager)
+
+  private def gtCookie(gt: GuestTokenManager) =
+    SetCookie(
+      Cookie.Response(
+        "gt",
+        gt.token.get,
+        Some(".twitter.com"),
+        Some(Path.root),
+        isSecure = true,
+        maxAge = Some(gt.setTime + GuestTokenValidity)
+      )
+    )
+  private def gtHeader(token: String)         =
+    Custom("x-guest-token", token)

--- a/domain/src/main/scala/zio/twitter/application/scraper/Utils.scala
+++ b/domain/src/main/scala/zio/twitter/application/scraper/Utils.scala
@@ -1,10 +1,48 @@
 package zio.twitter.application.scraper
 
+import zio.Duration
+import zio.NonEmptyChunk
+import zio.durationInt
+import zio.http.Header.AcceptLanguage.Multiple
+import zio.http.Header.AcceptLanguage.Single
+import zio.http.Header.Authorization
+import zio.http.Header.Referer
 import zio.http.Header.UserAgent
 import zio.http.Header.UserAgent.*
+import zio.http.Headers
+import zio.http.URL
 
 import java.time.LocalDate
 import scala.util.Random
+
+private[scraper] object TwitterUtils:
+  private val ApiAuthorizationHeaderValue =
+    "AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs=1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA"
+
+  def getHeaders(baseUrl: URL): Headers =
+    Headers(
+      Authorization.Bearer(ApiAuthorizationHeaderValue),
+      Referer(baseUrl),
+      Multiple(
+        NonEmptyChunk(Single("en-US", Some(0.5)), Single("en", Some(0.5)))
+      )
+    )
+
+  enum TwitterSearchScraperMode:
+    case Live, Top, User
+
+  enum TwitterApiType:
+    case GraphQL
+
+  enum ScrollDirection:
+    case Top, Bottom, Both
+
+  final case class GuestTokenManager(
+    token: Option[String] = None,
+    setTime: Duration = 0.seconds
+  ):
+    def reset: GuestTokenManager = copy(token = None, setTime = 0.seconds)
+end TwitterUtils
 
 def randUserAgent: UserAgent =
   val version = lerp(

--- a/domain/src/main/scala/zio/twitter/domain/scraper/ValueClasses.scala
+++ b/domain/src/main/scala/zio/twitter/domain/scraper/ValueClasses.scala
@@ -1,0 +1,12 @@
+package zio.twitter.domain.scraper
+
+import zio.prelude.Assertion
+import zio.prelude.Assertion.isEmptyString
+import zio.prelude.Subtype
+
+object ValueClasses:
+
+  object NonEmptyString extends Subtype[String]:
+    override inline def assertion: Assertion[String] =
+      !isEmptyString
+  type NonEmptyString = NonEmptyString.Type

--- a/domain/src/test/scala/zio/twitter/application/scraper/TwitterSearchScraperSpec.scala
+++ b/domain/src/test/scala/zio/twitter/application/scraper/TwitterSearchScraperSpec.scala
@@ -1,0 +1,8 @@
+package zio.twitter.application.scraper
+
+import zio.test.ZIOSpecDefault
+
+//object TwitterSearchScraperSpec extends ZIOSpecDefault:
+
+//  def spec =
+//    suite("Getting data is correct")(test(""))

--- a/project/Libs.scala
+++ b/project/Libs.scala
@@ -5,12 +5,16 @@ object Libs {
 
   val zio        = "dev.zio" %% "zio"          % zioV
   val zioHttp    = "dev.zio" %% "zio-http"     % zioHttpV
+  val zioPrelude = "dev.zio" %% "zio-prelude"  % zioPreludeV
+  val zioJson    = "dev.zio" %% "zio-json"     % zioJsonV
   val zioTest    = "dev.zio" %% "zio-test"     % zioV % Test
   val zioTestSbt = "dev.zio" %% "zio-test-sbt" % zioV % Test
 }
 
 object Versions {
 
-  val zioV     = "2.0.15"
-  val zioHttpV = "3.0.0-RC2"
+  val zioV        = "2.0.15"
+  val zioHttpV    = "3.0.0-RC2"
+  val zioPreludeV = "1.0.0-RC19"
+  val zioJsonV    = "0.6.0"
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -21,5 +21,6 @@ object Settings {
       testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
     )
 
-  val commonDependencies = zio :: zioHttp :: zioTest :: zioTestSbt :: Nil
+  val commonDependencies =
+    zio :: zioHttp :: zioPrelude :: zioJson :: zioTest :: zioTestSbt :: Nil
 }


### PR DESCRIPTION
Get a guest token from Twitter's response. Then save its value in `x-guest-token` header and in `gt` cookie for next requests to Twitter.